### PR TITLE
propagate stack from a failure

### DIFF
--- a/lib/bluebird-retry.js
+++ b/lib/bluebird-retry.js
@@ -63,6 +63,7 @@ function retry(func, options) {
                     var timeout = new Error('operation timed out after ' + (now - start) + ' ms, ' + tries + ' tries' + ' failure: ' + err.message);
                     timeout.failure = err;
                     timeout.code = 'ETIMEDOUT';
+                    timeout.stack = err.stack;
                     return Promise.reject(timeout);
                 } else {
                     var delay = interval - (now - tryStart);


### PR DESCRIPTION
if retry fails due to an exception, propagate the error stack
from the exception into the exception thrown by rety.  only
the very last stack is propagated but often there is one failure
happening repeatedly and this lets us see it.