### PR TITLE
rework cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ Will display:
 Error: operation timed out
 ```
 
-## Cancellation
+## Stopping
 
-The library also supports canceling the retry loop before the timeout occurs by throwing a new instance of `retry.CancelError`. For example:
+The library also supports stopping the retry loop before the timeout occurs by throwing a new instance of `retry.StopError` from within the called function.
+
+For example:
 
 ```js
 var retry = require('bluebird-retry');
@@ -108,7 +110,7 @@ var swing = function() {
     i++;
     console.log('strike ' + i);
     if (i == 3) {
-        throw new retry.CancelError('yer out');
+        throw new retry.StopError('yer out');
     }
     throw new Error('still up at bat');
 };
@@ -128,4 +130,4 @@ strike 3
 yer out
 ```
 
-The `CancelError` constructor accepts one argument. If it is invoked with an instance of `Error`, then the promise is rejected with that error argument. Otherwise the promise is rejected with the `CancelError` itself.
+The `StopError` constructor accepts one argument. If it is invoked with an instance of `Error`, then the promise is rejected with that error argument. Otherwise the promise is rejected with the `StopError` itself.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ It supports regular intervals and exponential backoff with a configurable
 limit, as well as an overall timeout for the operation that limits the
 number of retries.
 
-Uses the bluebird library to supply the promise implementation.
+The bluebird library supplies the promise implementation.
 
-Sample usage:
+## Basic Usage
 
 ```js
 var Promise = require('bluebird');
@@ -44,6 +44,8 @@ i succeed the third time
 
 Note that the rejection messages from the first two failed calls
 were absorbed by `retry`.
+
+## Options
 
 The maximum number of retries and controls for the interval
 between retries can be specified via the `options` parameter:
@@ -93,3 +95,37 @@ Will display:
 2014-05-29T23:17:36.661Z
 Error: operation timed out
 ```
+
+## Cancellation
+
+The library also supports canceling the retry loop before the timeout occurs by throwing a new instance of `retry.CancelError`. For example:
+
+```js
+var retry = require('bluebird-retry');
+var i = 0;
+var err;
+var swing = function() {
+    i++;
+    console.log('strike ' + i);
+    if (i == 3) {
+        throw new retry.CancelError('yer out');
+    }
+    throw new Error('still up at bat');
+};
+
+retry(swing, {timeout: 10000})
+.catch(function(e) {
+    console.log(e.message)
+});
+```
+
+Will display:
+
+```
+strike 1
+strike 2
+strike 3
+yer out
+```
+
+The `CancelError` constructor accepts one argument. If it is invoked with an instance of `Error`, then the promise is rejected with that error argument. Otherwise the promise is rejected with the `CancelError` itself.

--- a/browser/bluebird-retry.js
+++ b/browser/bluebird-retry.js
@@ -45,26 +45,26 @@
             //
             // Otherwise the cancel error object itself is propagated to the caller.
             //
-            function CancelError(err) {
-                this.name = 'CancelError';
+            function StopError(err) {
+                this.name = 'StopError';
                 if (err instanceof Error) {
                     this.err = err;
                 } else {
                     this.message = err || 'cancelled';
                 }
             }
-            CancelError.prototype = Object.create(Error.prototype);
-            retry.CancelError = CancelError;    // Retry `func` until it succeeds.
-                                                //
-                                                // Waits `options.interval` milliseconds (default 1000) between attempts.
-                                                //
-                                                // Increases wait by a factor of `options.backoff` each interval, up to
-                                                // a limit of `options.max_interval`.
-                                                //
-                                                // Keeps trying until `options.timeout` milliseconds have elapsed,
-                                                // or `options.max_tries` have been attempted, whichever comes first.
-                                                //
-                                                // If neither is specified, then the default is to make 5 attempts.
+            StopError.prototype = Object.create(Error.prototype);
+            retry.StopError = StopError;    // Retry `func` until it succeeds.
+                                            //
+                                            // Waits `options.interval` milliseconds (default 1000) between attempts.
+                                            //
+                                            // Increases wait by a factor of `options.backoff` each interval, up to
+                                            // a limit of `options.max_interval`.
+                                            //
+                                            // Keeps trying until `options.timeout` milliseconds have elapsed,
+                                            // or `options.max_tries` have been attempted, whichever comes first.
+                                            //
+                                            // If neither is specified, then the default is to make 5 attempts.
             // Retry `func` until it succeeds.
             //
             // Waits `options.interval` milliseconds (default 1000) between attempts.
@@ -96,7 +96,7 @@
                     return Promise.try(function () {
                         return func();
                     }).catch(function (err) {
-                        if (err instanceof CancelError) {
+                        if (err instanceof StopError) {
                             if (err.err instanceof Error) {
                                 return Promise.reject(err.err);
                             } else {

--- a/browser/specs/bluebird-retry.spec.js
+++ b/browser/specs/bluebird-retry.spec.js
@@ -32,17 +32,40 @@
     _require.cache = [];
     _require.modules = [
         function (module, exports) {
-            var Promise = _require(1);    // Retry `func` until it succeeds.
+            var Promise = _require(1);    // Subclass of Error that can be thrown to indicate that retry should stop.
                                           //
-                                          // Waits `options.interval` milliseconds (default 1000) between attempts.
+                                          // If called with an instance of Error subclass, then the retry promise will be
+                                          // rejected with the given error.
                                           //
-                                          // Increases wait by a factor of `options.backoff` each interval, up to
-                                          // a limit of `options.max_interval`.
+                                          // Otherwise the cancel error object itself is propagated to the caller.
                                           //
-                                          // Keeps trying until `options.timeout` milliseconds have elapsed,
-                                          // or `options.max_tries` have been attempted, whichever comes first.
-                                          //
-                                          // If neither is specified, then the default is to make 5 attempts.
+            // Subclass of Error that can be thrown to indicate that retry should stop.
+            //
+            // If called with an instance of Error subclass, then the retry promise will be
+            // rejected with the given error.
+            //
+            // Otherwise the cancel error object itself is propagated to the caller.
+            //
+            function CancelError(err) {
+                this.name = 'CancelError';
+                if (err instanceof Error) {
+                    this.err = err;
+                } else {
+                    this.message = err || 'cancelled';
+                }
+            }
+            CancelError.prototype = Object.create(Error.prototype);
+            retry.CancelError = CancelError;    // Retry `func` until it succeeds.
+                                                //
+                                                // Waits `options.interval` milliseconds (default 1000) between attempts.
+                                                //
+                                                // Increases wait by a factor of `options.backoff` each interval, up to
+                                                // a limit of `options.max_interval`.
+                                                //
+                                                // Keeps trying until `options.timeout` milliseconds have elapsed,
+                                                // or `options.max_tries` have been attempted, whichever comes first.
+                                                //
+                                                // If neither is specified, then the default is to make 5 attempts.
             // Retry `func` until it succeeds.
             //
             // Waits `options.interval` milliseconds (default 1000) between attempts.
@@ -68,25 +91,18 @@
                     max_tries = 5;
                 }
                 var tries = 0;
-                var start = new Date().getTime();    // populate the caller's argument with a cancel function
-                                                     // When invoked, we use its signal to break out of the retry loop
-                // populate the caller's argument with a cancel function
-                // When invoked, we use its signal to break out of the retry loop
-                var cancelled;
-                var cancel = function (err) {
-                    cancelled = true;
-                    if (!(err instanceof Error)) {
-                        err = new Error(err || 'cancelled');
-                    }
-                    throw err;
-                };
+                var start = new Date().getTime();
                 function try_once() {
                     var tryStart = new Date().getTime();
                     return Promise.try(function () {
-                        return func(cancel);
+                        return func();
                     }).catch(function (err) {
-                        if (cancelled) {
-                            return Promise.reject(err);
+                        if (err instanceof CancelError) {
+                            if (err.err instanceof Error) {
+                                return Promise.reject(err.err);
+                            } else {
+                                return Promise.reject(err);
+                            }
                         }
                         ++tries;
                         if (tries > 1) {
@@ -1886,19 +1902,26 @@
                         it('can cancel the retry event loop', function () {
                             // test various ways in which cancel() may be invoked
                             // by the caller & verify it's output error message
-                            // ie. input arg => output Error message
+                            // ie. input arg => output Error message / type
+                            function MyError(message) {
+                                this.name = 'MyError';
+                                Error.call(this);
+                                this.message = message;
+                                this.is_my_error = true;
+                            }
+                            MyError.prototype = Object.create(Error.prototype);
                             var test_args = [
                                     [
                                         undefined,
                                         'cancelled'
                                     ],
                                     [
-                                        'string error',
-                                        'string error'
+                                        'stop retrying',
+                                        'stop retrying'
                                     ],
                                     [
-                                        new Error('custom error'),
-                                        'custom error'
+                                        new MyError('test my error'),
+                                        'test my error'
                                     ]
                                 ];
                             var retry_opts = {
@@ -1908,18 +1931,22 @@
                             return Promise.all(_.map(test_args, function (arg_type) {
                                 var i = 0;
                                 var err;
-                                var op = function (cancel) {
+                                var op = function () {
                                     i++;
                                     if (i === 3) {
-                                        cancel(arg_type[0]);
+                                        throw new retry.CancelError(arg_type[0]);
                                     }
-                                    throw new Error();
+                                    throw new Error('keep trying');
                                 };
                                 return retry(op, retry_opts).catch(function (e) {
                                     err = e;
                                 }).then(function () {
                                     expect(i).to.equal(3);
                                     expect(err.message).equal(arg_type[1]);
+                                    if (arg_type[0] instanceof MyError) {
+                                        expect(err instanceof MyError).is.true;
+                                        expect(err.is_my_error).is.true;
+                                    }
                                 });
                             }));
                         });

--- a/browser/specs/bluebird-retry.spec.js
+++ b/browser/specs/bluebird-retry.spec.js
@@ -46,26 +46,26 @@
             //
             // Otherwise the cancel error object itself is propagated to the caller.
             //
-            function CancelError(err) {
-                this.name = 'CancelError';
+            function StopError(err) {
+                this.name = 'StopError';
                 if (err instanceof Error) {
                     this.err = err;
                 } else {
                     this.message = err || 'cancelled';
                 }
             }
-            CancelError.prototype = Object.create(Error.prototype);
-            retry.CancelError = CancelError;    // Retry `func` until it succeeds.
-                                                //
-                                                // Waits `options.interval` milliseconds (default 1000) between attempts.
-                                                //
-                                                // Increases wait by a factor of `options.backoff` each interval, up to
-                                                // a limit of `options.max_interval`.
-                                                //
-                                                // Keeps trying until `options.timeout` milliseconds have elapsed,
-                                                // or `options.max_tries` have been attempted, whichever comes first.
-                                                //
-                                                // If neither is specified, then the default is to make 5 attempts.
+            StopError.prototype = Object.create(Error.prototype);
+            retry.StopError = StopError;    // Retry `func` until it succeeds.
+                                            //
+                                            // Waits `options.interval` milliseconds (default 1000) between attempts.
+                                            //
+                                            // Increases wait by a factor of `options.backoff` each interval, up to
+                                            // a limit of `options.max_interval`.
+                                            //
+                                            // Keeps trying until `options.timeout` milliseconds have elapsed,
+                                            // or `options.max_tries` have been attempted, whichever comes first.
+                                            //
+                                            // If neither is specified, then the default is to make 5 attempts.
             // Retry `func` until it succeeds.
             //
             // Waits `options.interval` milliseconds (default 1000) between attempts.
@@ -97,7 +97,7 @@
                     return Promise.try(function () {
                         return func();
                     }).catch(function (err) {
-                        if (err instanceof CancelError) {
+                        if (err instanceof StopError) {
                             if (err.err instanceof Error) {
                                 return Promise.reject(err.err);
                             } else {
@@ -1934,7 +1934,7 @@
                                 var op = function () {
                                     i++;
                                     if (i === 3) {
-                                        throw new retry.CancelError(arg_type[0]);
+                                        throw new retry.StopError(arg_type[0]);
                                     }
                                     throw new Error('keep trying');
                                 };

--- a/lib/bluebird-retry.js
+++ b/lib/bluebird-retry.js
@@ -7,17 +7,17 @@ var Promise = require('bluebird');
 //
 // Otherwise the cancel error object itself is propagated to the caller.
 //
-function CancelError(err) {
-    this.name = 'CancelError';
+function StopError(err) {
+    this.name = 'StopError';
     if (err instanceof Error) {
         this.err = err
     } else {
         this.message = err || 'cancelled'
     }
 }
-CancelError.prototype = Object.create(Error.prototype);
+StopError.prototype = Object.create(Error.prototype);
 
-retry.CancelError = CancelError;
+retry.StopError = StopError;
 
 
 // Retry `func` until it succeeds.
@@ -58,7 +58,7 @@ function retry(func, options) {
                 return func();
             })
             .catch(function(err) {
-                if (err instanceof CancelError) {
+                if (err instanceof StopError) {
                     if (err.err instanceof Error) {
                         return Promise.reject(err.err);
                     } else {

--- a/lib/bluebird-retry.js
+++ b/lib/bluebird-retry.js
@@ -1,5 +1,25 @@
 var Promise = require('bluebird');
 
+// Subclass of Error that can be thrown to indicate that retry should stop.
+//
+// If called with an instance of Error subclass, then the retry promise will be
+// rejected with the given error.
+//
+// Otherwise the cancel error object itself is propagated to the caller.
+//
+function CancelError(err) {
+    this.name = 'CancelError';
+    if (err instanceof Error) {
+        this.err = err
+    } else {
+        this.message = err || 'cancelled'
+    }
+}
+CancelError.prototype = Object.create(Error.prototype);
+
+retry.CancelError = CancelError;
+
+
 // Retry `func` until it succeeds.
 //
 // Waits `options.interval` milliseconds (default 1000) between attempts.
@@ -32,25 +52,18 @@ function retry(func, options) {
     var tries = 0;
     var start = new Date().getTime();
 
-    // populate the caller's argument with a cancel function
-    // When invoked, we use its signal to break out of the retry loop
-    var cancelled;
-    var cancel = function(err) {
-        cancelled = true;
-        if (!(err instanceof Error)) {
-            err = new Error(err || 'cancelled');
-        }
-        throw err;
-    };
-
     function try_once() {
         var tryStart = new Date().getTime();
         return Promise.try(function() {
-                return func(cancel);
+                return func();
             })
             .catch(function(err) {
-                if (cancelled) {
-                    return Promise.reject(err);
+                if (err instanceof CancelError) {
+                    if (err.err instanceof Error) {
+                        return Promise.reject(err.err);
+                    } else {
+                        return Promise.reject(err);
+                    }
                 }
                 ++tries;
                 if (tries > 1) {

--- a/specs/bluebird-retry.spec.js
+++ b/specs/bluebird-retry.spec.js
@@ -190,7 +190,7 @@ describe('bluebird-retry', function() {
                     var op = function() {
                         i++;
                         if (i === 3) {
-                            throw new retry.CancelError(arg_type[0]);
+                            throw new retry.StopError(arg_type[0]);
                         }
                         throw new Error('keep trying');
                     };


### PR DESCRIPTION
Change the implementation of retry cancellation to use a subclass of Error and add documentation.

Addresses #9.