### PR TITLE
chore(dependencies): move underscore to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   },
   "homepage": "https://github.com/jut-io/bluebird-retry",
   "dependencies": {
-    "bluebird": ">=2.3.10",
-    "underscore": ">=1.7.0"
+    "bluebird": ">=2.3.10"
   },
   "devDependencies": {
     "chai": "^1.9.2",
     "grunt": "^0.4.5",
-    "grunt-dry": "^0.3.0"
+    "grunt-dry": "^0.3.0",
+    "underscore": ">=1.7.0"
   },
   "files": [
     "browser/*.js",


### PR DESCRIPTION
I'm not sure this is exactly what you want (not sure what step underscore is being used for), but it seems needless to bring in underscore as a dependency, at least in node. Looks like its only being used in the browser tests, and at that could be easily replaced. Figured I'd start the conversation with a PR :smile: