### PR TITLE
Bumped bluebird dependency to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/jut-io/bluebird-retry",
   "dependencies": {
-    "bluebird": ">=2.3.10"
+    "bluebird": ">=3.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.2",


### PR DESCRIPTION
All tests pass, but bluebird 3 gets cranky when a promise is rejected with a non-Error object - in this case ``StopError``. The rationale for this is [here](https://github.com/petkaantonov/bluebird/blob/master/docs/docs/warning-explanations.md#warning-a-promise-was-rejected-with-a-non-error) .  Leaving aside whether this is reasonable or not, it's obviously trivial enough to get ``StopError`` to extend ``Error`` if you want to; I didn't see anything in the bluebird source to suppress the warning.