### PR TITLE
make bluebird a peer dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4.2"
+  - "5.0"
+env:
+  - BLUEBIRD=bluebird@2
+  - BLUEBIRD=bluebird@3
 before_script:
   - npm install -g grunt-cli
+  - npm install $BLUEBIRD

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/jut-io/bluebird-retry/issues"
   },
   "homepage": "https://github.com/jut-io/bluebird-retry",
-  "dependencies": {
+  "peerDependencies": {
     "bluebird": ">=2.3.10"
   },
   "devDependencies": {


### PR DESCRIPTION
To support various versions of bluebird, change the package so that bluebird is now a peer dependency instead of a strict dependency.

Also update travis to test the various combinations of node and bluebird version.

Fixes #19.



